### PR TITLE
Add support for User and Channel models (#15).

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -7,6 +7,7 @@ import logging
 
 from . import async
 from . import connection
+from . import models
 from . import protocol
 
 __all__ = [ 'Error', 'AlreadyInChannel', 'NotInChannel', 'BasicClient' ]
@@ -29,7 +30,29 @@ class AlreadyInChannel(Error):
         self.channel = channel
 
 
-class BasicClient:
+class ClientType(type):
+    def _compose(c, name, field):
+        # We traverse the class's method resolution order to create the user and channel model classes.
+        # There is an assumption that the model classes for users and channels follow the same inheritance hierarchy as the client class, and we can avoid calling featurize().
+        seen = set()
+        bases = []
+
+        for mro_cls in c.mro():
+            inner = getattr(mro_cls, field, None)
+            if inner is not None and inner not in seen:
+                bases.append(inner)
+                seen.add(inner)
+
+        return type('{name}[{bases}]'.format(name=name, bases=', '.join(base.__name__ for base in bases)), tuple(bases), {})
+
+    def __new__(cls, name, bases, attrs):
+        c = super().__new__(cls, name, bases, attrs)
+        c.User = cls._compose(c, 'User', 'USER_MODEL')
+        c.Channel = cls._compose(c, 'Channel', 'CHANNEL_MODEL')
+        return c
+
+
+class BasicClient(metaclass=ClientType):
     """
     Base IRC client class.
     This class on its own is not complete: in order to be able to run properly, _has_message, _parse_message and _create_message have to be overloaded.
@@ -39,11 +62,13 @@ class BasicClient:
     RECONNECT_DELAYED = True
     RECONNECT_DELAYS = [0, 5, 10, 30, 120, 600]
 
+    USER_MODEL = models.User
+    CHANNEL_MODEL = models.Channel
+
     def __init__(self, nickname, fallback_nicknames=[], username=None, realname=None, **kwargs):
         """ Create a client. """
         self._nicknames = [nickname] + fallback_nicknames
-        self.username = username or nickname.lower()
-        self.realname = realname or nickname
+        self.user = self.User(self, nickname, realname or nickname, username or nickname.lower())
         self.eventloop = None
         self.own_eventloop = True
         self._reset_connection_attributes()
@@ -51,6 +76,18 @@ class BasicClient:
 
         if kwargs:
             self.logger.warning('Unused arguments: %s', ', '.join(kwargs.keys()))
+
+    @property
+    def nickname(self):
+        return self.user.nickname
+
+    @property
+    def username(self):
+        return self.user.username
+
+    @property
+    def realname(self):
+        return self.user.realname
 
     def _reset_attributes(self):
         """ Reset attributes. """
@@ -61,7 +98,6 @@ class BasicClient:
         # Low-level data stuff.
         self._last_data_received = time.time()
         self._receive_buffer = b''
-        self._pending = {}
         self._handler_top_level = False
         self._ping_checker_handle = None
 
@@ -69,7 +105,7 @@ class BasicClient:
         self.logger = logging.getLogger(__name__)
 
         # Public connection attributes.
-        self.nickname = DEFAULT_NICKNAME
+        self.user.nickname = DEFAULT_NICKNAME
         self.network = None
 
     def _reset_connection_attributes(self):
@@ -167,42 +203,34 @@ class BasicClient:
     ## Internal database management.
 
     def _create_channel(self, channel):
-        self.channels[channel] = {
-            'users': set(),
-        }
+        self.channels[channel] = self.Channel(self, channel)
 
     def _destroy_channel(self, channel):
         # Copy set to prevent a runtime error when destroying the user.
-        for user in set(self.channels[channel]['users']):
+        for user in set(self.channels[channel].users):
             self._destroy_user(user, channel)
         del self.channels[channel]
 
 
     def _create_user(self, nickname):
-        # Servers are NOT users.
-        if not nickname or '.' in nickname:
-            return
+        self.users[nickname] = self.User(self, nickname)
 
-        self.users[nickname] = {
-            'nickname': nickname,
-            'username': None,
-            'realname': None,
-            'hostname': None
-        }
+    def _get_user(self, nickname):
+        if nickname not in self.users:
+            self._create_user(nickname)
 
-    def _sync_user(self, nick, metadata):
-        # Create user in database.
-        if nick not in self.users:
-            self._create_user(nick)
-            if nick not in self.users:
-                return
+        return self.users[nickname]
 
-        self.users[nick].update(metadata)
+    def _get_channel(self, name):
+        if name not in self.channels:
+            self._create_channel(name)
+
+        return self.channels[name]
 
     def _rename_user(self, user, new):
         if user in self.users:
             self.users[new] = self.users[user]
-            self.users[new]['nickname'] = new
+            self.users[new].nickname = new
             del self.users[user]
         else:
             self._create_user(new)
@@ -211,9 +239,9 @@ class BasicClient:
 
         for ch in self.channels.values():
             # Rename user in channel list.
-            if user in ch['users']:
-                ch['users'].discard(user)
-                ch['users'].add(new)
+            if user in ch.users:
+                ch.users.discard(user)
+                ch.users.add(new)
 
     def _destroy_user(self, nickname, channel=None):
         if channel:
@@ -223,11 +251,11 @@ class BasicClient:
 
         for ch in channels:
             # Remove from nicklist.
-            ch['users'].discard(nickname)
+            ch.users.discard(nickname)
 
         # If we're not in any common channels with the user anymore, we have no reliable way to keep their info up-to-date.
         # Remove the user.
-        if not channel or not any(nickname in ch['users'] for ch in self.channels.values()):
+        if not channel or not any(nickname in ch.users for ch in self.channels.values()):
             del self.users[nickname]
 
     def _parse_user(self, data):
@@ -235,11 +263,11 @@ class BasicClient:
         raise NotImplementedError()
 
     def _format_user_mask(self, nickname):
-        user = self.users.get(nickname, { "nickname": nickname, "username": "*", "hostname": "*" })
-        return self._format_host_mask(user['nickname'], user['username'] or '*', user['hostname'] or '*')
-
-    def _format_host_mask(self, nick, user, host):
-        return '{n}!{u}@{h}'.format(n=nick, u=user, h=host)
+        if nickname in self.users:
+            user = self.users[nickname]
+        else:
+            user = self.User(self, nickname)
+        return user.hostmask
 
 
     ## IRC helpers.

--- a/pydle/features/account.py
+++ b/pydle/features/account.py
@@ -1,23 +1,28 @@
 ## account.py
 # Account system support.
+from pydle import models
 from pydle.features import rfc1459
+
+
+class AccountUser(models.User):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.account = None
+        self.identified = False
+
 
 class AccountSupport(rfc1459.RFC1459Support):
 
-    ## Internal.
+    USER_MODEL = AccountUser
 
-    def _create_user(self, nickname):
-        super()._create_user(nickname)
-        if nickname in self.users:
-            self.users[nickname].update({
-                'account': None,
-                'identified': False
-            })
+    ## Internal.
 
     def _rename_user(self, user, new):
         super()._rename_user(user, new)
         # Unset account info.
-        self._sync_user(new, { 'account': None, 'identified': False })
+        user = self._get_user(new)
+        user.account = None
+        user.identified = False
 
 
     ## IRC API.
@@ -27,8 +32,9 @@ class AccountSupport(rfc1459.RFC1459Support):
 
         # Add own info.
         if nickname in self._whois_info:
-            self._whois_info[nickname].setdefault('account', None)
-            self._whois_info[nickname].setdefault('identified', False)
+            whois_info = self._whois_info[nickname]
+            whois_info.account = None
+            whois_info.identified = False
 
         return future
 
@@ -38,24 +44,23 @@ class AccountSupport(rfc1459.RFC1459Support):
     def on_raw_307(self, message):
         """ WHOIS: User has identified for this nickname. (Anope) """
         target, nickname = message.params[:2]
-        info = {
-            'identified': True
-        }
 
         if nickname in self.users:
-            self._sync_user(nickname, info)
-        if nickname in self._pending['whois']:
-            self._whois_info[nickname].update(info)
+            user = self._get_user(nickname)
+            user.identified = True
+        if nickname in self._pending_whois:
+            whois_info = self._whois_info[nickname]
+            whois_info.identified = True
 
     def on_raw_330(self, message):
         """ WHOIS account name (Atheme). """
         target, nickname, account = message.params[:3]
-        info = {
-            'account': account,
-            'identified': True
-        }
 
         if nickname in self.users:
-            self._sync_user(nickname, info)
-        if nickname in self._pending['whois']:
-            self._whois_info[nickname].update(info)
+            user = self._get_user(nickname)
+            user.account = account
+            user.identified = True
+        if nickname in self._pending_whois:
+            whois_info = self._whois_info[nickname]
+            whois_info.account = account
+            whois_info.identified = True

--- a/pydle/features/ircv3/ircv3_1.py
+++ b/pydle/features/ircv3/ircv3_1.py
@@ -42,38 +42,25 @@ class IRCv3_1Support(sasl.SASLSupport, cap.CapabilityNegotiationSupport, account
         if 'account-notify' not in self._capabilities or not self._capabilities['account-notify']:
             return
 
-        nick, metadata = self._parse_user(message.source)
+        user = self._parse_and_sync_user(message.source)
         account = message.params[0]
-
-        if nick not in self.users:
-            return
-
-        self._sync_user(nick, metadata)
-        if account == NO_ACCOUNT:
-            self._sync_user(nick, { 'account': None, 'identified': False })
-        else:
-            self._sync_user(nick, { 'account': account, 'identified': True })
+        if account != NO_ACCOUNT:
+            user.account = account
+            user.identified = True
 
     def on_raw_away(self, message):
         """ Process AWAY messages. """
         if 'away-notify' not in self._capabilities or not self._capabilities['away-notify']:
             return
 
-        nick, metadata = self._parse_user(message.source)
-        if nick not in self.users:
-            return
-
-        self._sync_user(nick, metadata)
-        self.users[nick]['away'] = len(message.params) > 0
-        self.users[nick]['away_message'] = message.params[0] if len(message.params) > 0 else None
+        user = self._parse_and_syn_user(message.source)
+        user.away_message = message.params[0] if len(message.params) > 0 else None
 
     def on_raw_join(self, message):
         """ Process extended JOIN messages. """
         if 'extended-join' in self._capabilities and self._capabilities['extended-join']:
-            nick, metadata = self._parse_user(message.source)
+            user = self._parse_and_sync_user(message.source)
             channels, account, realname = message.params
-
-            self._sync_user(nick, metadata)
 
             # Emit a fake join message.
             fakemsg = self._create_message('JOIN', channels, source=message.source)
@@ -81,7 +68,8 @@ class IRCv3_1Support(sasl.SASLSupport, cap.CapabilityNegotiationSupport, account
 
             if account == NO_ACCOUNT:
                 account = None
-            self.users[nick]['account'] = account
-            self.users[nick]['realname'] = realname
+            user.account = account
+            user.identified = user.account is not None
+            user.realname = realname
         else:
             super().on_raw_join(message)

--- a/pydle/features/ircv3/ircv3_2.py
+++ b/pydle/features/ircv3/ircv3_2.py
@@ -42,8 +42,5 @@ class IRCv3_2Support(metadata.MetadataSupport, monitor.MonitoringSupport, tags.T
             return
 
         # Update user and host.
-        metadata = {
-            'username': message.params[0],
-            'hostname': message.params[1]
-        }
-        self._sync_user(nick, metadata)
+        user = self._get_user(nick)
+        user.username, user.hostname = message.params[:2]

--- a/pydle/features/ircv3/monitor.py
+++ b/pydle/features/ircv3/monitor.py
@@ -21,16 +21,16 @@ class MonitoringSupport(cap.CapabilityNegotiationSupport):
 
         for ch in channels:
             # Remove from nicklist.
-            ch['users'].discard(nickname)
+            ch.users.discard(nickname)
 
             # Remove from statuses.
             for status in self._nickname_prefixes.values():
-                if status in ch['modes'] and nickname in ch['modes'][status]:
-                    ch['modes'][status].remove(nickname)
+                if status in ch.modes and nickname in ch.modes[status]:
+                    ch.modes[status].remove(nickname)
 
         # If we're not in any common channels with the user anymore, we have no reliable way to keep their info up-to-date.
         # Remove the user.
-        if (monitor_override or not self.is_monitoring(nickname)) and (not channel or not any(nickname in ch['users'] for ch in self.channels.values())):
+        if (monitor_override or not self.is_monitoring(nickname)) and (not channel or not any(nickname in ch.users for ch in self.channels.values())):
             del self.users[nickname]
 
 

--- a/pydle/features/isupport.py
+++ b/pydle/features/isupport.py
@@ -3,6 +3,8 @@
 # See: http://tools.ietf.org/html/draft-hardy-irc-isupport-00
 import collections
 import pydle.protocol
+
+from pydle import models
 from pydle.features import rfc1459
 
 __all__ = [ 'ISUPPORTSupport' ]
@@ -13,8 +15,21 @@ BAN_EXCEPT_MODE = 'e'
 INVITE_EXCEPT_MODE = 'I'
 
 
+class ISUPPORTChannel(models.Channel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if 'EXCEPTS' in self.client._isupport:
+            self.except_list = None
+
+        if 'INVEX' in self.client._isupport:
+            self.invite_except_list = None
+
+
 class ISUPPORTSupport(rfc1459.RFC1459Support):
     """ ISUPPORT support. """
+
+    Channel = ISUPPORTChannel
 
     ## Internal overrides.
 
@@ -23,15 +38,6 @@ class ISUPPORTSupport(rfc1459.RFC1459Support):
         self._isupport = {}
         self._extban_types = []
         self._extban_prefix = None
-
-    def _create_channel(self, channel):
-        """ Create channel with optional ban and invite exception lists. """
-        super()._create_channel(channel)
-        if 'EXCEPTS' in self._isupport:
-            self.channels[channel]['exceptlist'] = None
-        if 'INVEX' in self._isupport:
-            self.channels[channel]['inviteexceptlist'] = None
-
 
     ## Command handlers.
 

--- a/pydle/features/tls.py
+++ b/pydle/features/tls.py
@@ -65,7 +65,7 @@ class TLSSupport(rfc1459.RFC1459Support):
 
         # Add field that determines if the target user is connected over TLS.
         if nickname in self._whois_info:
-            self._whois_info[nickname].setdefault('secure', False)
+            self._whois_info[nickname].secure = False
 
         return future
 
@@ -92,12 +92,9 @@ class TLSSupport(rfc1459.RFC1459Support):
     def on_raw_671(self, message):
         """ WHOIS: user is connected securely. """
         target, nickname = message.params[:2]
-        info = {
-            'secure': True
-        }
 
         if nickname in self._whois_info:
-            self._whois_info[nickname].update(info)
+            self._whois_info[nickname].secure = True
 
     def on_raw_691(self, message):
         """ Error setting up TLS server-side. """

--- a/pydle/features/whox.py
+++ b/pydle/features/whox.py
@@ -13,10 +13,10 @@ class WHOXSupport(isupport.ISUPPORTSupport, account.AccountSupport):
     def on_raw_join(self, message):
         """ Override JOIN to send WHOX. """
         super().on_raw_join(message)
-        nick, metadata = self._parse_user(message.source)
+        user = self._parse_and_sync_user(message.source)
         channels = message.params[0].split(',')
 
-        if self.is_same_nick(self.nickname, nick):
+        if self.is_same_nick(self.nickname, user.nickname):
             # We joined.
             if 'WHOX' in self._isupport and self._isupport['WHOX']:
                 # Get more relevant channel info thanks to WHOX.
@@ -33,14 +33,8 @@ class WHOXSupport(isupport.ISUPPORTSupport, account.AccountSupport):
             return
 
         # Great. Extract relevant information.
-        metadata = {
-            'nickname': message.params[4],
-            'username': message.params[2],
-            'realname': message.params[6],
-            'hostname': message.params[3],
-        }
-        if message.params[5] != NO_ACCOUNT:
-            metadata['identified'] = True
-            metadata['account'] = message.params[5]
-
-        self._sync_user(metadata['nickname'], metadata)
+        user = self._get_user(message.params[4])
+        user.username = message.params[2]
+        user.realname = message.params[6]
+        user.hostname = message.params[3]
+        user.account = message.params[5] if message.params[5] != NO_ACCOUNT else None

--- a/pydle/models.py
+++ b/pydle/models.py
@@ -1,0 +1,48 @@
+## models.py
+# User and channel model classes.
+import warnings
+
+
+class User:
+    def __init__(self, client, nickname, realname=None, username=None, hostname=None):
+        self.client = client
+        self.nickname = nickname
+        self.realname = realname
+        self.username = username
+        self.hostname = hostname
+
+    @property
+    def name(self):
+        return self.nickname
+
+    @property
+    def hostmask(self):
+        return '{n}!{u}@{h}'.format(n=self.nickname, u=self.username or '*', h=self.hostname or '*')
+
+    def __getitem__(self, k):
+        warnings.warn('Use of `user["attr"]` is deprecated. Please use `user.attr`.', DeprecationWarning)
+        return getattr(self, k)
+
+    def __setitem__(self, k, v):
+        warnings.warn('Use of `user["attr"]` is deprecated. Please use `user.attr`.', DeprecationWarning)
+        setattr(self, k, v)
+
+
+class Channel:
+    def __init__(self, client, name):
+        self.client = client
+        self.name = name
+        self.users = set()
+
+    def __getitem__(self, k):
+        warnings.warn('Use of `channel["attr"]` is deprecated. Please use `channel.attr`.', DeprecationWarning)
+        return getattr(self, k)
+
+    def __setitem__(self, k, v):
+        warnings.warn('Use of `channel["attr"]` is deprecated. Please use `channel.attr`.', DeprecationWarning)
+        setattr(self, k, v)
+
+
+class Server:
+    def __init__(self, name):
+        self.name = name

--- a/tests/test_client_channels.py
+++ b/tests/test_client_channels.py
@@ -24,7 +24,7 @@ def test_client_is_channel(server, client):
 def test_channel_creation(server, client):
     client._create_channel('#pydle')
     assert '#pydle' in client.channels
-    assert client.channels['#pydle']['users'] == set()
+    assert client.channels['#pydle'].users == set()
 
 @with_client()
 def test_channel_destruction(server, client):
@@ -36,7 +36,7 @@ def test_channel_destruction(server, client):
 def test_channel_user_destruction(server, client):
     client._create_channel('#pydle')
     client._create_user('WiZ')
-    client.channels['#pydle']['users'].add('WiZ')
+    client.channels['#pydle'].users.add('WiZ')
 
     client._destroy_channel('#pydle')
     assert '#pydle' not in client.channels

--- a/tests/test_client_users.py
+++ b/tests/test_client_users.py
@@ -13,12 +13,7 @@ def test_client_same_nick(server, client):
 def test_user_creation(server, client):
     client._create_user('WiZ')
     assert 'WiZ' in client.users
-    assert client.users['WiZ']['nickname'] == 'WiZ'
-
-@with_client()
-def test_user_invalid_creation(server, client):
-    client._create_user('irc.fbi.gov')
-    assert 'irc.fbi.gov' not in client.users
+    assert client.users['WiZ'].nickname == 'WiZ'
 
 
 @with_client()
@@ -28,7 +23,7 @@ def test_user_renaming(server, client):
 
     assert 'WiZ' not in client.users
     assert 'jilles' in client.users
-    assert client.users['jilles']['nickname'] == 'jilles'
+    assert client.users['jilles'].nickname == 'jilles'
 
 @with_client()
 def test_user_renaming_creation(server, client):
@@ -37,22 +32,16 @@ def test_user_renaming_creation(server, client):
     assert 'WiZ' in client.users
     assert 'null' not in client.users
 
-@with_client()
-def test_user_renaming_invalid_creation(server, client):
-    client._rename_user('null', 'irc.fbi.gov')
-
-    assert 'irc.fbi.gov' not in client.users
-    assert 'null' not in client.users
 
 @with_client()
 def test_user_renaming_channel_users(server, client):
     client._create_user('WiZ')
     client._create_channel('#lobby')
-    client.channels['#lobby']['users'].add('WiZ')
+    client.channels['#lobby'].users.add('WiZ')
 
     client._rename_user('WiZ', 'jilles')
-    assert 'WiZ' not in client.channels['#lobby']['users']
-    assert 'jilles' in client.channels['#lobby']['users']
+    assert 'WiZ' not in client.channels['#lobby'].users
+    assert 'jilles' in client.channels['#lobby'].users
 
 
 @with_client()
@@ -66,53 +55,42 @@ def test_user_deletion(server, client):
 def test_user_channel_deletion(server, client):
     client._create_channel('#lobby')
     client._create_user('WiZ')
-    client.channels['#lobby']['users'].add('WiZ')
+    client.channels['#lobby'].users.add('WiZ')
 
     client._destroy_user('WiZ', '#lobby')
     assert 'WiZ' not in client.users
-    assert client.channels['#lobby']['users'] == set()
+    assert client.channels['#lobby'].users == set()
 
 @with_client()
 def test_user_channel_incomplete_deletion(server, client):
     client._create_channel('#lobby')
     client._create_channel('#foo')
     client._create_user('WiZ')
-    client.channels['#lobby']['users'].add('WiZ')
-    client.channels['#foo']['users'].add('WiZ')
+    client.channels['#lobby'].users.add('WiZ')
+    client.channels['#foo'].users.add('WiZ')
 
     client._destroy_user('WiZ', '#lobby')
     assert 'WiZ' in client.users
-    assert client.channels['#lobby']['users'] == set()
+    assert client.channels['#lobby'].users == set()
 
 
 @with_client()
-def test_user_synchronization(server, client):
-    client._create_user('WiZ')
-    client._sync_user('WiZ', { 'hostname': 'og.irc.developer' })
-
-    assert client.users['WiZ']['hostname'] == 'og.irc.developer'
-
-@with_client()
-def test_user_synchronization_creation(server, client):
-    client._sync_user('WiZ', {})
+def test_user_get(server, client):
+    client._get_user('WiZ')
     assert 'WiZ' in client.users
-
-@with_client()
-def test_user_invalid_synchronization(server, client):
-    client._sync_user('irc.fbi.gov', {})
-    assert 'irc.fbi.gov' not in client.users
 
 
 @with_client()
 def test_user_mask_format(server, client):
     client._create_user('WiZ')
+    wiz = client.users['WiZ']
     assert client._format_user_mask('WiZ') == 'WiZ!*@*'
 
-    client._sync_user('WiZ', { 'username': 'wiz' })
+    wiz.username = 'wiz'
     assert client._format_user_mask('WiZ') == 'WiZ!wiz@*'
 
-    client._sync_user('WiZ', { 'hostname': 'og.irc.developer' })
+    wiz.hostname = 'og.irc.developer'
     assert client._format_user_mask('WiZ') == 'WiZ!wiz@og.irc.developer'
 
-    client._sync_user('WiZ', { 'username': None })
+    wiz.username = None
     assert client._format_user_mask('WiZ') == 'WiZ!*@og.irc.developer'


### PR DESCRIPTION
This is extremely backwards-incompatible with v0.8 as it changes many
interfaces for interacting with user and channel information, namely:
- All previous dictionary fields have been converted to attributes,
  e.g. user['username'] is now user.username. This extends to results
  from WHOIS (WhoisInfo) and WHOWAS (WhowasInfo).
- Instead of nicknames and channel names, User and Channel models are
  now passed to on_\* hooks (BREAKING).
- _sync_user has been completely removed and replaced with
  _parse_and_sync_user (and, to some extent, _get_or_create_user).
  Everything that made use of _parse_user now also synchronizes with
  the user database for consistency (may be breaking).
- A new metaclass, ClientMeta, has been introduced to allow dynamic
  composition of the User and Channel classes on the feature classes
  (internal only).
- User/Channel objects have the message() method when RFC1459 support
  is active (feature).
