### PR TITLE
Fixing nick tracking when the user changes nicks

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -4,6 +4,7 @@ import time
 import datetime
 import itertools
 import logging
+import copy
 
 from . import async
 from . import connection
@@ -201,7 +202,7 @@ class BasicClient:
 
     def _rename_user(self, user, new):
         if user in self.users:
-            self.users[new] = self.users[user]
+            self.users[new] = copy.copy(self.users[user])
             self.users[new]['nickname'] = new
             del self.users[user]
         else:


### PR DESCRIPTION
Without this, **both** lists (new and old) are deleted when the user changes nicks, losing all the data stored (accountname, host, etc).