### PR TITLE
Properly detecting IRCv3.2 capabilities with arguments

### DIFF
--- a/pydle/features/ircv3/cap.py
+++ b/pydle/features/ircv3/cap.py
@@ -42,7 +42,7 @@ class CapabilityNegotiationSupport(rfc1459.RFC1459Support):
     def _capability_normalize(self, cap):
         cap = cap.lstrip(PREFIXES).lower()
         if CAPABILITY_VALUE_DIVIDER in cap:
-            cap, _, value = cap[1:].partition(CAPABILITY_VALUE_DIVIDER)
+            cap, _, value = cap.partition(CAPABILITY_VALUE_DIVIDER)
         else:
             value = None
 

--- a/pydle/features/ircv3/sasl.py
+++ b/pydle/features/ircv3/sasl.py
@@ -42,7 +42,7 @@ class SASLSupport(cap.CapabilityNegotiationSupport):
     def _sasl_start(self):
         """ Initiate SASL authentication. """
         # The rest will be handled in on_raw_authenticate()/_sasl_respond().
-        if not self._sasl_mechanisms or 'PLAIN' in self._sasl_mechanisms:
+        if not self._sasl_mechanisms or 'plain' in self._sasl_mechanisms:
             self.rawmsg('AUTHENTICATE', 'PLAIN')
             # Set a timeout handler.
             self._sasl_timer = self.eventloop.schedule_in(self.SASL_TIMEOUT, self._sasl_abort)


### PR DESCRIPTION
For some reason it was stripping the first character of capabilities with arguments, `sasl=plain,authcookie,external,ecdsa-nist256p-challenge` became `asl, plain,authcookie,external,ecdsa-nist256p-challenge`.
This breaks SASL on ircv3.2-capable servers