### PR TITLE
Implementing IRCv3 cap-notify to request capabilities available after…

### DIFF
--- a/pydle/features/ircv3/cap.py
+++ b/pydle/features/ircv3/cap.py
@@ -164,7 +164,15 @@ class CapabilityNegotiationSupport(rfc1459.RFC1459Support):
         # If we have no capabilities left to process, end it.
         if not self._capabilities_requested and not self._capabilities_negotiating:
             self.rawmsg('CAP', 'END')
+    
+    def on_raw_cap_del(self, params):
+        for capab in params[0].split():
+            capab, _ = self._capability_normalize(capab)
+            self._capabilities[capab] = False
+            self._capabilities_requested.discard(capab)
 
+    def on_raw_cap_new(self, params):
+        self.on_raw_cap_ls(params)
 
     def on_raw_410(self, message):
         """ Unknown CAP subcommand or CAP error. Force-end negotiations. """

--- a/pydle/features/ircv3/cap.py
+++ b/pydle/features/ircv3/cap.py
@@ -166,6 +166,10 @@ class CapabilityNegotiationSupport(rfc1459.RFC1459Support):
             self.rawmsg('CAP', 'END')
     
     def on_raw_cap_del(self, params):
+        for capab in params[0].split():
+            attr = 'on_capability_{}_disabled'.format(pydle.protocol.identifierify(capab))
+            if self._capabilities.get(capab, False) and hasattr(self, attr):
+                getattr(self, attr)()
         self.on_raw_cap_nak(params)
 
     def on_raw_cap_new(self, params):

--- a/pydle/features/ircv3/cap.py
+++ b/pydle/features/ircv3/cap.py
@@ -166,10 +166,7 @@ class CapabilityNegotiationSupport(rfc1459.RFC1459Support):
             self.rawmsg('CAP', 'END')
     
     def on_raw_cap_del(self, params):
-        for capab in params[0].split():
-            capab, _ = self._capability_normalize(capab)
-            self._capabilities[capab] = False
-            self._capabilities_requested.discard(capab)
+        self.on_raw_cap_nak(params)
 
     def on_raw_cap_new(self, params):
         self.on_raw_cap_ls(params)

--- a/pydle/features/ircv3/ircv3_2.py
+++ b/pydle/features/ircv3/ircv3_2.py
@@ -12,7 +12,10 @@ class IRCv3_2Support(metadata.MetadataSupport, monitor.MonitoringSupport, tags.T
     """ Support for some of IRCv3.2's extensions. Currently supported: chghost, userhost-in-names. """
 
     ## IRC callbacks.
-
+    def on_capability_cap_notify_available(self, value):
+        """ Take note of new or removed capabilities. """
+        return True
+    
     def on_capability_chghost_available(self, value):
         """ Server reply to indicate a user we are in a common channel with changed user and/or host. """
         return True


### PR DESCRIPTION
… we connected or to mark removed capabilities.

An example is (as explained in the sasl-3.2 spec) when services are offline when we connect but then come back after we're connected. With this the client will automatically request the capability and finish identifying.