### PR TITLE
reconnect to connection reset fix

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -100,7 +100,12 @@ class BasicClient:
         # Reset attributes and connect.
         if not reconnect:
             self._reset_connection_attributes()
-        self._connect(hostname=hostname, port=port, reconnect=reconnect, **kwargs)
+        try:
+            self._connect(hostname=hostname, port=port, reconnect=reconnect, **kwargs)
+        except ConnectionRefusedError:
+            self.on_disconnect(
+                expected=False,
+            )
 
         # Set logger name.
         if self.server_tag:

--- a/pydle/client.py
+++ b/pydle/client.py
@@ -102,7 +102,7 @@ class BasicClient:
             self._reset_connection_attributes()
         try:
             self._connect(hostname=hostname, port=port, reconnect=reconnect, **kwargs)
-        except ConnectionRefusedError:
+        except OSError:
             self.on_disconnect(
                 expected=False,
             )


### PR DESCRIPTION
if connection fails during initializtion - reconnect mechanism isn't called and an exception is thrown,

can be reproduced by:
 - starting an irc server
```docker run -it --rm -p 6667:6667 carver/ngircd```
  - connecting to it using a pydle bot
  - killing the irc server

this pull request fixes this issue by calling the on_disconnect to start the reconnect mechanism