### PR TITLE
reconnect-fix

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -100,7 +100,12 @@ class BasicClient:
         # Reset attributes and connect.
         if not reconnect:
             self._reset_connection_attributes()
-        self._connect(hostname=hostname, port=port, reconnect=reconnect, **kwargs)
+        try:
+            self._connect(hostname=hostname, port=port, reconnect=reconnect, **kwargs)
+        except OSError:
+            self.on_disconnect(
+                expected=False,
+            )
 
         # Set logger name.
         if self.server_tag:
@@ -363,7 +368,7 @@ class BasicClient:
     def on_data(self, data):
         """ Handle received data. """
         self._receive_buffer += data
-        
+
         # Schedule new timeout event.
         self.eventloop.unschedule(self._ping_checker_handle)
         self._ping_checker_handle = self.eventloop.schedule_in(PING_TIMEOUT, self._perform_ping_timeout)


### PR DESCRIPTION
if connection fails during initializtion - reconnect mechanism isn't called and an exception is thrown,

can be reproduced by:

starting an irc server
docker run -it --rm -p 6667:6667 carver/ngircd
connecting to it using a pydle bot
killing the irc server
this pull request fixes this issue by calling the on_disconnect to start the reconnect mechanism