### PR TITLE
Fixing TLS verification, removing callback and verify flag (CRL)

### DIFF
--- a/pydle/connection.py
+++ b/pydle/connection.py
@@ -129,31 +129,20 @@ class Connection:
 
         # Set TLS verification options.
         if self.tls_verify:
-            # Set our custom verification callback, if the library supports it.
-            # jbrunink: This does not seem to work.
-            #if hasattr(self.tls_context, 'set_servername_callback'):
-                #self.tls_context.set_servername_callback(self.verify_tls)
-
             # Load certificate verification paths.
             self.tls_context.set_default_verify_paths()
             if sys.platform in DEFAULT_CA_PATHS and path.isdir(DEFAULT_CA_PATHS[sys.platform]):
                 self.tls_context.load_verify_locations(capath=DEFAULT_CA_PATHS[sys.platform])
 
             # If we want to verify the TLS connection, we first need a certicate.
-            # Check this certificate and its entire chain, if possible, against revocation lists.
+            # Check this certificate and its entire chain.
             self.tls_context.verify_mode = ssl.CERT_REQUIRED
-            # jbrunink: This does not seem to work.
-            #if hasattr(self.tls_context, 'verify_flags'):
-                #self.tls_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
 
         self.socket = self.tls_context.wrap_socket(self.socket,
             # Send hostname over SNI, but only if our TLS library supports it.
             server_hostname=self.hostname if ssl.HAS_SNI else None)
 
-        # Verify the peer certificate here if our TLS library doesn't have callback functionality.
-        # jbrunink: This does not seem to work.
-        #if self.tls_verify and not hasattr(self.tls_context, 'set_servername_callback'):
-            #self.verify_tls(self.socket, self.hostname, self.tls_context, as_callback=False)
+        # Verify the peer certificate.
         if self.tls_verify:
             self.verify_tls(self.socket, self.hostname, self.tls_context, as_callback=False)
 

--- a/pydle/connection.py
+++ b/pydle/connection.py
@@ -130,8 +130,9 @@ class Connection:
         # Set TLS verification options.
         if self.tls_verify:
             # Set our custom verification callback, if the library supports it.
-            if hasattr(self.tls_context, 'set_servername_callback'):
-                self.tls_context.set_servername_callback(self.verify_tls)
+            # jbrunink: This does not seem to work.
+            #if hasattr(self.tls_context, 'set_servername_callback'):
+                #self.tls_context.set_servername_callback(self.verify_tls)
 
             # Load certificate verification paths.
             self.tls_context.set_default_verify_paths()
@@ -141,15 +142,19 @@ class Connection:
             # If we want to verify the TLS connection, we first need a certicate.
             # Check this certificate and its entire chain, if possible, against revocation lists.
             self.tls_context.verify_mode = ssl.CERT_REQUIRED
-            if hasattr(self.tls_context, 'verify_flags'):
-                self.tls_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
+            # jbrunink: This does not seem to work.
+            #if hasattr(self.tls_context, 'verify_flags'):
+                #self.tls_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
 
         self.socket = self.tls_context.wrap_socket(self.socket,
             # Send hostname over SNI, but only if our TLS library supports it.
             server_hostname=self.hostname if ssl.HAS_SNI else None)
 
         # Verify the peer certificate here if our TLS library doesn't have callback functionality.
-        if self.tls_verify and not hasattr(self.tls_context, 'set_servername_callback'):
+        # jbrunink: This does not seem to work.
+        #if self.tls_verify and not hasattr(self.tls_context, 'set_servername_callback'):
+            #self.verify_tls(self.socket, self.hostname, self.tls_context, as_callback=False)
+        if self.tls_verify:
             self.verify_tls(self.socket, self.hostname, self.tls_context, as_callback=False)
 
     def verify_tls(self, socket, hostname, context, as_callback=True):


### PR DESCRIPTION
Hi folks,

First of all, I'm new to Python and programming overall. (and English)

After doing some research and having experienced some undesired behaviour in the TLS verification process implemented in Pydle I'm proposing the following changes. 

- Removing the 'set_servername_callback', the function being called requests the peer certificate, this cannot be safely done because the certificate is only available after Client Hello and there's no way to safely call this after that being done. Instead of the callback method the non-callback method is always being used. 
- Removing the VERIFY_CRL_CHECK_CHAIN flag, it appears Python at the moment can check against CRL, but Python does not automatically download the CRLs so at the moment this seems to be useless and most importantly fails when the tls_verify has been set to True. 

Since I'm an utter noob, I'd like to ask the experts of this world to double check this pull.

Thanks.