### PR TITLE
Prevent excess flood in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ class MyOwnBot(pydle.Client):
          await self.join('#bottest')
 
     async def on_message(self, target, source, message):
-         await self.message(target, message)
+         if source != self.nickname:
+            await self.message(target, message)
 
 client = MyOwnBot('MyBot', realname='My Bot')
 client.run('irc.rizon.net', tls=True, tls_verify=False)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ class MyOwnBot(pydle.Client):
          await self.join('#bottest')
 
     async def on_message(self, target, source, message):
+         # don't respond to our own messages, as this leads to a positive feedback loop
          if source != self.nickname:
             await self.message(target, message)
 


### PR DESCRIPTION
Issue:

The echo bot as presented in the readme is flawed, and will respond to its own messages.
This causes a positive feedback loop, excessively flooding the channel this bot is run within.

These commits correct the positive feedback loop by preventing the example bot from responding to itself. 

