### PR TITLE
Various reconnection fixes

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -121,13 +121,15 @@ class BasicClient:
             if self._ping_checker_handle:
                 self._ping_checker_handle.cancel()
 
-
             # Schedule disconnect.
             await self._disconnect(expected)
 
     async def _disconnect(self, expected):
         # Shutdown connection.
         await self.connection.disconnect()
+
+        # Reset any attributes.
+        self._reset_attributes()
 
         # Callback.
         await self.on_disconnect(expected)
@@ -142,9 +144,6 @@ class BasicClient:
         # Shut down event loop.
         if expected and self.own_eventloop:
             self.connection.stop()
-
-        # Reset any attributes.
-        self._reset_attributes()
 
     async def _connect(self, hostname, port, reconnect=False, channels=[],
                        encoding=protocol.DEFAULT_ENCODING, source_address=None):

--- a/pydle/client.py
+++ b/pydle/client.py
@@ -1,11 +1,9 @@
 ## client.py
 # Basic IRC client implementation.
 import logging
-from asyncio import ensure_future, new_event_loop, BaseEventLoop, gather, TimerHandle, get_event_loop
-from typing import Set
+from asyncio import ensure_future, new_event_loop, gather, get_event_loop, sleep
 
-from . import connection
-from . import protocol
+from . import connection, protocol
 
 __all__ = ['Error', 'AlreadyInChannel', 'NotInChannel', 'BasicClient', 'ClientPool']
 DEFAULT_NICKNAME = '<unregistered>'
@@ -327,7 +325,8 @@ class BasicClient:
                     self.logger.error('Unexpected disconnect. Attempting to reconnect.')
 
                 # Wait and reconnect.
-                self.eventloop.call_soon(delay, self.connect(reconnect=True))
+                await sleep(delay)
+                await self.connect(reconnect=True)
             else:
                 self.logger.error('Unexpected disconnect. Giving up.')
 

--- a/pydle/features/ircv3/cap.py
+++ b/pydle/features/ircv3/cap.py
@@ -31,6 +31,7 @@ class CapabilityNegotiationSupport(rfc1459.RFC1459Support):
     async def _register(self):
         """ Hijack registration to send a CAP LS first. """
         if self.registered:
+            self.logger.debug("skipping cap registration, already registered!")
             return
 
         # Ask server to list capabilities.

--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -6,8 +6,7 @@ import ipaddress
 import itertools
 
 from pydle.client import BasicClient, NotInChannel, AlreadyInChannel
-from . import parsing
-from . import protocol
+from . import parsing, protocol
 
 
 class RFC1459Support(BasicClient):
@@ -194,7 +193,6 @@ class RFC1459Support(BasicClient):
         # And initiate the IRC connection.
         await self._register()
 
-
     async def _register(self):
         """ Perform IRC connection registration. """
         if self.registered:
@@ -271,14 +269,13 @@ class RFC1459Support(BasicClient):
         else:
             await self.rawmsg('PART', channel)
 
-
     async def kick(self, channel, target, reason=None):
         """ Kick user from channel. """
         if not self.in_channel(channel):
             raise NotInChannel(channel)
 
         if reason:
-           await self.rawmsg('KICK', channel, target, reason)
+            await self.rawmsg('KICK', channel, target, reason)
         else:
             await self.rawmsg('KICK', channel, target)
 
@@ -325,7 +322,7 @@ class RFC1459Support(BasicClient):
             message = self.DEFAULT_QUIT_MESSAGE
 
         await self.rawmsg('QUIT', message)
-        self.disconnect(expected=True)
+        await self.disconnect(expected=True)
 
     async def cycle(self, channel):
         """ Rejoin channel. """
@@ -613,7 +610,7 @@ class RFC1459Support(BasicClient):
 
         await self.on_kill(target, by, reason)
         if self.is_same_nick(self.nickname, target):
-            self.disconnect(expected=False)
+            await self.disconnect(expected=False)
         else:
             self._destroy_user(target)
 
@@ -725,7 +722,7 @@ class RFC1459Support(BasicClient):
             self._destroy_user(nick)
         # Else, we quit.
         elif self.connected:
-            self.disconnect(expected=True)
+            await self.disconnect(expected=True)
 
     async def on_raw_topic(self, message):
         """ TOPIC command. """

--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -460,6 +460,9 @@ class RFC1459Support(BasicClient):
         for channel in self._autojoin_channels:
             await self.join(channel)
 
+        # super call
+        await super().on_connect()
+
     async def on_invite(self, channel, by):
         """ Callback called when the client was invited into a channel by someone. """
         pass


### PR DESCRIPTION
An issue exists within Pydle's reconnection code, which was most probably introduced in #79 .

During reconnection after a graceless disconnection a bad call to `call_soon` was made.
The offending line, 
```py
self.eventloop.call_soon(delay, self.connect(reconnect=True))
```
The first error here is the signature for `call_soon` is `(callback, delay)`; the arguments in our call are out of order.
Secondly, `call_soon` expects a synchronous callback which won't work since `self.connect` is now asynchronous. 

The solution was to properly re-implement the desired end behavior using modern asyncio features. We pause the disconnect coroutine via `asyncio.sleep(delay)`, then await `connection()`.

A small lingering issue seems to be Pydle takes a long time reconnecting, it seems an issue remains where the first reconnection attempt times out however the second attempt succeeds. 
closes #101 
closes #103
closes #99 
