### PR TITLE
#77 Fix reconnect resetting the password

### DIFF
--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -188,8 +188,11 @@ class RFC1459Support(BasicClient):
 
         # Connect...
         await super().connect(hostname, port, **kwargs)
-        # Set password.
-        self.password = password
+
+        # Check if a password was provided and we don't already have one
+        if password is not None and self.password:
+            # if so, set the password.
+            self.password = password
         # And initiate the IRC connection.
         await self._register()
 


### PR DESCRIPTION
Fixes the `self.password` field from being reset during re-connection. 

Changes made
-------------
calling `connect(reconnect=True)` will not reset `self.password` to `None` , the root cause of #77 .

Behaviorally, pydle will now check if it *had* a password set, and if so it will not set it to `None` automatically during reconnect handling. 
closes #77