### PR TITLE
Split users by space only.

### DIFF
--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -914,7 +914,7 @@ class RFC1459Support(BasicClient):
             self.channels[channel]['public'] = False
 
         # Update channel user list.
-        for entry in names.split():
+        for entry in names.split(' '):
             statuses = []
             # Make entry safe for _parse_user().
             safe_entry = entry.lstrip(''.join(self._nickname_prefixes.keys()))


### PR DESCRIPTION
This PR resolves #113 (IRCv3 user tracking with non-standard hostmasks)

Pydle improperly handles non-standard whitespace characters in usernames and hostmasks, which causes the reported issue in #113.

While the issue stems from Rizon breaking from established standards and on its own is grounds to reject #113 as invalid, Upon closer reading of the RFC specifications I noticed that Pydle is slightly non-compliant.

Specifically I will cite a note in [RFC 1459 (IRC)](http://www.irc.org/tech_docs/rfc1459.html) page 8:

```    1) <SPACE> is consists only of SPACE character(s) (0x20).
     Specially notice that TABULATION, and all other control
     characters are considered NON-WHITE-SPACE.
```

This means the IRC formatting characters inserted into the host masks, while non-standard, should not be considered whitespace.

Python's `str.split()` method, in its default invocation, treats *any* non-rendering character - such as the IRC formatting characters - as whitespace.
This fact directly causes phantom users to be detected as Pydle leaves a channel, thereby causing pydle to attempt to destroy tracked users that arn't actually tracked.

these phantom users are what lead to the reported exception being raised in #113.

Therefore, We can fix #113 at the same time as fixing the above compliance issue by splitting only on valid whitespace characters: ` `

This PR patches the erroneous `.split()` call to only split on the space character as per the RFC.