### PR TITLE
Ctcp fixes

### DIFF
--- a/pydle/features/ctcp.py
+++ b/pydle/features/ctcp.py
@@ -84,14 +84,14 @@ class CTCPSupport(rfc1459.RFC1459Support):
 
         if is_ctcp(msg):
             self._sync_user(nick, metadata)
-            type, response = parse_ctcp(msg)
+            _type, response = parse_ctcp(msg)
 
             # Find dedicated handler if it exists.
-            attr = 'on_ctcp_' + pydle.protocol.identifierify(type) + '_reply'
+            attr = 'on_ctcp_' + pydle.protocol.identifierify(_type) + '_reply'
             if hasattr(self, attr):
                 await getattr(self, attr)(user, target, response)
             # Invoke global handler.
-            await self.on_ctcp_reply(user, target, type, response)
+            await self.on_ctcp_reply(user, target, _type, response)
         else:
             await super().on_raw_notice(message)
 

--- a/pydle/features/ctcp.py
+++ b/pydle/features/ctcp.py
@@ -2,7 +2,7 @@
 # Client-to-Client-Protocol (CTCP) support.
 import pydle.protocol
 from pydle.features import rfc1459
-
+from pydle import client
 __all__ = [ 'CTCPSupport' ]
 
 

--- a/pydle/features/ctcp.py
+++ b/pydle/features/ctcp.py
@@ -36,7 +36,7 @@ class CTCPSupport(rfc1459.RFC1459Support):
         import pydle
 
         version = '{name} v{ver}'.format(name=pydle.__name__, ver=pydle.__version__)
-        self.ctcp_reply(by, 'VERSION', version)
+        await self.ctcp_reply(by, 'VERSION', version)
 
 
     ## IRC API.

--- a/pydle/features/ctcp.py
+++ b/pydle/features/ctcp.py
@@ -89,9 +89,9 @@ class CTCPSupport(rfc1459.RFC1459Support):
             # Find dedicated handler if it exists.
             attr = 'on_ctcp_' + pydle.protocol.identifierify(_type) + '_reply'
             if hasattr(self, attr):
-                await getattr(self, attr)(user, target, response)
+                await getattr(self, attr)(nick, target, response)
             # Invoke global handler.
-            await self.on_ctcp_reply(user, target, _type, response)
+            await self.on_ctcp_reply(nick, target, _type, response)
         else:
             await super().on_raw_notice(message)
 


### PR DESCRIPTION
This pull request adjusts several issues found in the CTCP handling library, which prevented proper handling of ctcp messages.

Validation test:
```
>unknown[pydle]< CTCP HI
>unknown[pydle]< CTCP HI fo
* unknown[pydle] has quit (Read error)
* unknown[pydle] (~unknownpy@674CBF4E.74FC38EB.24F6D0A2.IP) has joined
>unknown[pydle]< CTCP HI fo
* Received a CTCP HI fo from unknown[pydle]
>unknown[pydle]< CTCP HI fo fo
* Received a CTCP HI fo fo from unknown[pydle]
>unknown[pydle]< CTCP VERSION
-unknown[pydle]- VERSION pydle v0.9.1
```

relevent ctcp callback:
```py
    async def on_ctcp(self, by, target, what, contents):
        print(f"on_ctcp invoked with by='{by}'\ttarget='{target}'\twhat='{what}'\tcontents = {contents}")
        await self.ctcp(by, what, contents=contents)

```