### PR TITLE
Handle IRCv3 tag escape sequences

### DIFF
--- a/tests/test_ircv3.py
+++ b/tests/test_ircv3.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pydle.features import ircv3
+
+pytestmark = pytest.mark.new_test
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        (
+                rb"@+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message",
+                {"+example": """raw+:=,escaped; \\"""}
+        ),
+        (
+            rb"@+example=\foo\bar :irc.example.com NOTICE #channel :Message",
+            {"+example": "foobar"}
+        ),
+    ]
+)
+def test_tagged_message_escape_sequences(payload, expected):
+    message = ircv3.tags.TaggedMessage.parse(payload)
+
+    assert message.tags == expected

--- a/tests/test_ircv3.py
+++ b/tests/test_ircv3.py
@@ -2,7 +2,7 @@ import pytest
 
 from pydle.features import ircv3
 
-pytestmark = pytest.mark.new_test
+pytestmark = pytest.mark.unit
 
 
 @pytest.mark.parametrize(
@@ -13,8 +13,8 @@ pytestmark = pytest.mark.new_test
                 {"+example": """raw+:=,escaped; \\"""}
         ),
         (
-            rb"@+example=\foo\bar :irc.example.com NOTICE #channel :Message",
-            {"+example": "foobar"}
+                rb"@+example=\foo\bar :irc.example.com NOTICE #channel :Message",
+                {"+example": "foobar"}
         ),
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,4 @@ markers =
     slow: may take several seconds or more to complete.
     meta: tests the test suite itself.
     real: tests pydle against a real server. Requires PYDLE_TESTS_REAL_HOST and PYDLE_TESTS_REAL_PORT environment variables.
+    new_test: new tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ markers =
     slow: may take several seconds or more to complete.
     meta: tests the test suite itself.
     real: tests pydle against a real server. Requires PYDLE_TESTS_REAL_HOST and PYDLE_TESTS_REAL_PORT environment variables.
-    new_test: new tests
+    unit: unit tests


### PR DESCRIPTION
Handle IRCv3 escape sequences, which are not the same as python's  using the spec defined in https://ircv3.net/specs/extensions/message-tags.html



 fixes #123