### PR TITLE
Fix #134

### DIFF
--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -923,6 +923,9 @@ class RFC1459Support(BasicClient):
             safe_entry = entry.lstrip(''.join(self._nickname_prefixes.keys()))
             # Parse entry and update database.
             nick, metadata = self._parse_user(safe_entry)
+            if not nick:
+                # nonsense nickname
+                continue
             self._sync_user(nick, metadata)
 
             # Get prefixes.


### PR DESCRIPTION
This PR takes the minimal approach to resolving #134 , by simply ignoring a null when parsing users to add to a channel, thus avoiding the null later on during channel destruction (and potentially breaking userland code in the public `on_part` callback)