### PR TITLE
Disconnect clients from pool

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -469,7 +469,7 @@ class ClientPool:
         """ Remove client from pool. """
         self.clients.remove(client)
         del self.connect_args[client]
-        client.disconnect()
+        asyncio.run_coroutine_threadsafe(client.disconnect(expected=True), self.eventloop)
 
     def __contains__(self, item):
         return item in self.clients
@@ -491,6 +491,3 @@ class ClientPool:
 
         # run the clients
         self.eventloop.run_forever()
-
-        for client in self.clients:
-            client.disconnect()


### PR DESCRIPTION
Calling coroutines outside of event loop does not work very well. Adding
it to the event loop instead.

Maybe I'm missing something but I do not understand how you are suppose to disconnect pydle. Calling disconnect() on BasicClient from inside the event loop or adding the coroutine similar to what I've done for the pool is possible. But I do not see how disconnecting via the pool is possible as it is calling a coroutine from a function.

Thoughts?