### PR TITLE
Fix use of mutable default arguments

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -56,10 +56,10 @@ class BasicClient:
         )
         self.READ_TIMEOUT = value
 
-    def __init__(self, nickname, fallback_nicknames=[], username=None, realname=None,
+    def __init__(self, nickname, fallback_nicknames=None, username=None, realname=None,
                  eventloop=None, **kwargs):
         """ Create a client. """
-        self._nicknames = [nickname] + fallback_nicknames
+        self._nicknames = [nickname] + (fallback_nicknames or [])
         self.username = username or nickname.lower()
         self.realname = realname or nickname
         if eventloop:
@@ -149,12 +149,12 @@ class BasicClient:
         if expected and self.own_eventloop:
             self.connection.stop()
 
-    async def _connect(self, hostname, port, reconnect=False, channels=[],
+    async def _connect(self, hostname, port, reconnect=False, channels=None,
                        encoding=protocol.DEFAULT_ENCODING, source_address=None):
         """ Connect to IRC host. """
         # Create connection if we can't reuse it.
         if not reconnect or not self.connection:
-            self._autojoin_channels = channels
+            self._autojoin_channels = channels or []
             self.connection = connection.Connection(hostname, port, source_address=source_address,
                                                     eventloop=self.eventloop)
             self.encoding = encoding

--- a/pydle/features/ircv3/tags.py
+++ b/pydle/features/ircv3/tags.py
@@ -109,9 +109,9 @@ class TaggedMessage(rfc1459.RFC1459Message):
 
 
 class TaggedMessageSupport(rfc1459.RFC1459Support):
-    def _create_message(self, command, *params, tags={}, **kwargs):
+    def _create_message(self, command, *params, tags=None, **kwargs):
         message = super()._create_message(command, *params, **kwargs)
-        return TaggedMessage(tags=tags, **message._kw)
+        return TaggedMessage(tags=tags or {}, **message._kw)
 
     def _parse_message(self):
         sep = rfc1459.protocol.MINIMAL_LINE_SEPARATOR.encode(self.encoding)

--- a/pydle/features/tls.py
+++ b/pydle/features/tls.py
@@ -34,13 +34,13 @@ class TLSSupport(rfc1459.RFC1459Support):
                 port = rfc1459.protocol.DEFAULT_PORT
         return await super().connect(hostname, port, tls=tls, **kwargs)
 
-    async def _connect(self, hostname, port, reconnect=False, password=None, encoding=pydle.protocol.DEFAULT_ENCODING, channels=[], tls=False, tls_verify=False, source_address=None):
+    async def _connect(self, hostname, port, reconnect=False, password=None, encoding=pydle.protocol.DEFAULT_ENCODING, channels=None, tls=False, tls_verify=False, source_address=None):
         """ Connect to IRC server, optionally over TLS. """
         self.password = password
 
         # Create connection if we can't reuse it.
         if not reconnect:
-            self._autojoin_channels = channels
+            self._autojoin_channels = channels or []
             self.connection = connection.Connection(hostname, port,
                 source_address=source_address,
                 tls=tls, tls_verify=tls_verify,


### PR DESCRIPTION
[Mutable default arguments](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments) were used in a few places, which is a common Python pitfall. I've replaced them with the correct idiom of defaulting to `None` and assigning an empty list in the body.