### PR TITLE
`monitor` support fixes

### DIFF
--- a/pydle/features/ircv3/monitor.py
+++ b/pydle/features/ircv3/monitor.py
@@ -38,7 +38,7 @@ class MonitoringSupport(cap.CapabilityNegotiationSupport):
 
     def monitor(self, target):
         """ Start monitoring the online status of a user. Returns whether or not the server supports monitoring. """
-        if 'monitor-notify' in self._capabilities and not self.is_monitoring(target):
+        if 'MONITOR' in self._isupport and not self.is_monitoring(target):
             yield from self.rawmsg('MONITOR', '+', target)
             self._monitoring.add(target)
             return True
@@ -47,7 +47,7 @@ class MonitoringSupport(cap.CapabilityNegotiationSupport):
 
     def unmonitor(self, target):
         """ Stop monitoring the online status of a user. Returns whether or not the server supports monitoring. """
-        if 'monitor-notify' in self._capabilities and self.is_monitoring(target):
+        if 'MONITOR' in self._isupport and self.is_monitoring(target):
             yield from self.rawmsg('MONITOR', '-', target)
             self._monitoring.remove(target)
             return True

--- a/pydle/features/ircv3/monitor.py
+++ b/pydle/features/ircv3/monitor.py
@@ -42,8 +42,7 @@ class MonitoringSupport(isupport.ISUPPORTSupport):
             await self.rawmsg('MONITOR', '+', target)
             self._monitoring.add(target)
             return True
-        else:
-            return False
+        return False
 
     async def unmonitor(self, target):
         """ Stop monitoring the online status of a user. Returns whether or not the server supports monitoring. """
@@ -51,8 +50,7 @@ class MonitoringSupport(isupport.ISUPPORTSupport):
             await self.rawmsg('MONITOR', '-', target)
             self._monitoring.remove(target)
             return True
-        else:
-            return False
+        return False
 
     def is_monitoring(self, target):
         """ Return whether or not we are monitoring the target's online status. """

--- a/pydle/features/ircv3/monitor.py
+++ b/pydle/features/ircv3/monitor.py
@@ -36,19 +36,19 @@ class MonitoringSupport(cap.CapabilityNegotiationSupport):
 
     ## API.
 
-    def monitor(self, target):
+    async def monitor(self, target):
         """ Start monitoring the online status of a user. Returns whether or not the server supports monitoring. """
         if 'MONITOR' in self._isupport and not self.is_monitoring(target):
-            yield from self.rawmsg('MONITOR', '+', target)
+            await self.rawmsg('MONITOR', '+', target)
             self._monitoring.add(target)
             return True
         else:
             return False
 
-    def unmonitor(self, target):
+    async def unmonitor(self, target):
         """ Stop monitoring the online status of a user. Returns whether or not the server supports monitoring. """
         if 'MONITOR' in self._isupport and self.is_monitoring(target):
-            yield from self.rawmsg('MONITOR', '-', target)
+            await self.rawmsg('MONITOR', '-', target)
             self._monitoring.remove(target)
             return True
         else:

--- a/pydle/features/ircv3/monitor.py
+++ b/pydle/features/ircv3/monitor.py
@@ -1,9 +1,9 @@
 ## monitor.py
 # Online status monitoring support.
-from . import cap
+from .. import isupport
 
 
-class MonitoringSupport(cap.CapabilityNegotiationSupport):
+class MonitoringSupport(isupport.ISUPPORTSupport):
     """ Support for monitoring the online/offline status of certain targets. """
 
     ## Internals.
@@ -97,7 +97,7 @@ class MonitoringSupport(cap.CapabilityNegotiationSupport):
             nickname, metadata = self._parse_user(target)
             self._monitoring.add(nickname)
 
-    on_raw_733 = cap.CapabilityNegotiationSupport._ignored  # End of MONITOR list.
+    on_raw_733 = isupport.ISUPPORTSupport._ignored  # End of MONITOR list.
 
     async def on_raw_734(self, message):
         """ Monitor list is full, can't add target. """

--- a/pydle/features/isupport.py
+++ b/pydle/features/isupport.py
@@ -179,6 +179,9 @@ class ISUPPORTSupport(rfc1459.RFC1459Support):
         """ Maximum number of variable modes to change in a single MODE command. """
         self._mode_limit = int(value)
 
+    async def on_isupport_monitor(self, value):
+        self._monitor_limit = int(value)
+
     async def on_isupport_namesx(self, value):
         """ Let the server know we do in fact support NAMESX. Effectively the same as CAP multi-prefix. """
         await self.rawmsg('PROTOCTL', 'NAMESX')


### PR DESCRIPTION
Fixes many issues with Pydle's support for the `monitor` extension, as detailed in #143.

**Summary**
- Support is indicated by `RPL_ISUPPORT`, not capabilities.
- `monitor` and `unmonitor` methods were made to be coroutines, as they were not before
  - This addresses in part #142
- Fixed incorrect assumption that `RPL_MON*` replies would always return bare nicknames, when in fact the server may return full `nick!user@host` masks.

Feel free to let me know of anything else you found, or go ahead and push to this branch.