### PR TITLE
[#151] Fixup irccat.py example

### DIFF
--- a/pydle/utils/irccat.py
+++ b/pydle/utils/irccat.py
@@ -8,57 +8,59 @@ import logging
 import asyncio
 from asyncio.streams import FlowControlMixin
 
-from .. import  Client, __version__
+from .. import Client, __version__
 from . import _args
 import asyncio
 
+
 class IRCCat(Client):
     """ irccat. Takes raw messages on stdin, dumps raw messages to stdout. Life has never been easier. """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.async_stdin = None
 
-    @asyncio.coroutine
-    def _send(self, data):
-        sys.stdout.write(data)
-        yield from super()._send(data)
+    async def _send(self, data):
+        await super(IRCCat, self)._send(data)
 
-    @asyncio.coroutine
-    def process_stdin(self):
+    async def process_stdin(self):
         """ Yes. """
-        loop = self.eventloop.loop
+        loop = asyncio.get_event_loop()
 
         self.async_stdin = asyncio.StreamReader()
         reader_protocol = asyncio.StreamReaderProtocol(self.async_stdin)
-        yield from loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
+        await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
 
         while True:
-            line = yield from self.async_stdin.readline()
+            line = await self.async_stdin.readline()
             if not line:
                 break
-            yield from self.raw(line.decode('utf-8'))
+            await self.raw(line.decode('utf-8'))
 
-        yield from self.quit('EOF')
+        await self.quit('EOF')
 
-    @asyncio.coroutine
-    def on_raw(self, message):
+    async def on_raw(self, message):
         print(message._raw)
-        yield from super().on_raw(message)
+        await super().on_raw(message)
 
-    @asyncio.coroutine
-    def on_ctcp_version(self, source, target, contents):
-        self.ctcp_reply(source, 'VERSION', 'pydle-irccat v{}'.format(__version__))
+    async def on_ctcp_version(self, source, target, contents):
+        await self.ctcp_reply(source, 'VERSION', 'pydle-irccat v{}'.format(__version__))
+
+
+async def _main():
+    # Create client.
+    irccat, connect = _args.client_from_args('irccat', default_nick='irccat',
+                                             description='Process raw IRC messages from stdin, dump received IRC messages to stdout.',
+                                             cls=IRCCat)
+    await connect()
+    while True:
+        await irccat.process_stdin()
 
 
 def main():
     # Setup logging.
     logging.basicConfig(format='!! %(levelname)s: %(message)s')
-
-    # Create client.
-    irccat, connect = _args.client_from_args('irccat', default_nick='irccat', description='Process raw IRC messages from stdin, dump received IRC messages to stdout.', cls=IRCCat)
-
-    irccat.eventloop.schedule_async(connect())
-    irccat.eventloop.run_with(irccat.process_stdin())
+    asyncio.get_event_loop().run_until_complete(_main())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR attempts to modernize the `irccat` example.

In multiple places there was legacy references to async abstractions that I believe have been removed.
In many places there was legacy (and deprecated) async syntax which has been corrected.

The `main` function has been abstracted to run a `async def _main` to simplify the logic.

`asyncio.get_event_loop().run_until_complete(_main())` was chosen over the simpler `asyncio.run(_main())` syntax since this library supports 3.6, where `asyncio.run` wasn't introduced until Python 3.7 .

closes #151 