### PR TITLE
Enable RplWhoisHostSupport implementation 

### DIFF
--- a/pydle/features/__init__.py
+++ b/pydle/features/__init__.py
@@ -7,6 +7,8 @@ from .tls import TLSSupport
 from .isupport import ISUPPORTSupport
 from .whox import WHOXSupport
 from .ircv3 import IRCv3Support, IRCv3_1Support, IRCv3_2Support
+from .rpl_whoishost import RplWhoisHostSupport
 
-ALL = [ IRCv3Support, WHOXSupport, ISUPPORTSupport, CTCPSupport, AccountSupport, TLSSupport, RFC1459Support ]
-LITE = [ WHOXSupport, ISUPPORTSupport, CTCPSupport, TLSSupport, RFC1459Support ]
+ALL = [IRCv3Support, WHOXSupport, ISUPPORTSupport, CTCPSupport, AccountSupport, TLSSupport, RFC1459Support,
+       RplWhoisHostSupport]
+LITE = [WHOXSupport, ISUPPORTSupport, CTCPSupport, TLSSupport, RFC1459Support]


### PR DESCRIPTION
The 0.9.4 version of Pydle implements RplWhoisHostSupport, but does not actually enable it, neither as a featurize()able module or as part of the standard client. This PR adds RplWhoisHostSupport to the default, full featured client and leaves it out in the Lite client.