### PR TITLE
[#161] Remove Deprecated Marker from WHOIS

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -189,7 +189,7 @@ Fortunately, pydle utilizes asyncio coroutines_ which allow you to handle a bloc
 while still retaining the benefits of asynchronous program flow. Coroutines allow pydle to be notified when a blocking operation is done,
 and then resume execution of the calling function appropriately. That way, blocking operations do not block the entire program flow.
 
-In order for a function to be declared as a coroutine, it has to be declared as an ``async def`` function or decorated with the :meth:`asyncio.coroutine` decorator.
+In order for a function to be declared as a coroutine, it has to be declared as an ``async def`` function.
 It can then call functions that would normally block using Python's ``await`` operator.
 Since a function that calls a blocking function is itself blocking too, it has to be declared a coroutine as well.
 

--- a/pydle/features/account.py
+++ b/pydle/features/account.py
@@ -22,9 +22,8 @@ class AccountSupport(rfc1459.RFC1459Support):
         self.whois(new)
 
     ## IRC API.
-    @asyncio.coroutine
-    def whois(self, nickname):
-        info = yield from super().whois(nickname)
+    async def whois(self, nickname):
+        info = await super().whois(nickname)
         info.setdefault('account', None)
         info.setdefault('identified', False)
         return info


### PR DESCRIPTION
Resolves #161, related to #142

@asyncio.coroutine was deprecated since version 3.8 and will be removed in version 3.11.

This change does not drop support for any previously supported versions of Python for Pydle.