### PR TITLE
Implement decorator-based event handler registration

### DIFF
--- a/pydle/client.py
+++ b/pydle/client.py
@@ -6,6 +6,8 @@ from asyncio import new_event_loop, gather, get_event_loop, sleep
 
 from . import connection, protocol
 import warnings
+import inspect
+import functools
 
 __all__ = ['Error', 'AlreadyInChannel', 'NotInChannel', 'BasicClient', 'ClientPool']
 DEFAULT_NICKNAME = '<unregistered>'
@@ -447,6 +449,24 @@ class BasicClient:
 
         # This isn't a handler, just raise an error.
         raise AttributeError(attr)
+
+    # Bonus features
+    def event(self, func):
+        """
+        Registers the specified `func` to handle events of the same name.
+
+        The func will always be called with, at least, the bot's `self` instance.
+
+        Returns decorated func, unmodified.
+        """
+        if not func.__name__.startswith("on_"):
+            raise NameError("Event handlers must start with 'on_'.")
+
+        if not inspect.iscoroutinefunction(func):
+            raise AssertionError("Wrapped function {!r} must be an `async def` function.".format(func))
+        setattr(self, func.__name__, functools.partial(func, self))
+
+        return func
 
 
 class ClientPool:


### PR DESCRIPTION
Closes #145 

 - drops support for python<3.5 if we haven't done that already.