### PR TITLE
Add Missing awaits in coroutine calls

### DIFF
--- a/pydle/features/ctcp.py
+++ b/pydle/features/ctcp.py
@@ -64,7 +64,7 @@ class CTCPSupport(rfc1459.RFC1459Support):
         target, msg = message.params
 
         if is_ctcp(msg):
-            self._sync_user(nick, metadata)
+            await self._sync_user(nick, metadata)
             type, contents = parse_ctcp(msg)
 
             # Find dedicated handler if it exists.
@@ -83,7 +83,7 @@ class CTCPSupport(rfc1459.RFC1459Support):
         target, msg = message.params
 
         if is_ctcp(msg):
-            self._sync_user(nick, metadata)
+            await self._sync_user(nick, metadata)
             _type, response = parse_ctcp(msg)
 
             # Find dedicated handler if it exists.

--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -547,7 +547,7 @@ class RFC1459Support(BasicClient):
     async def on_raw_invite(self, message):
         """ INVITE command. """
         nick, metadata = self._parse_user(message.source)
-        self._sync_user(nick, metadata)
+        await self._sync_user(nick, metadata)
 
         target, channel = message.params
         target, metadata = self._parse_user(target)
@@ -583,7 +583,7 @@ class RFC1459Support(BasicClient):
     async def on_raw_kick(self, message):
         """ KICK command. """
         kicker, kickermeta = self._parse_user(message.source)
-        self._sync_user(kicker, kickermeta)
+        await self._sync_user(kicker, kickermeta)
 
         if len(message.params) > 2:
             channels, targets, reason = message.params
@@ -596,7 +596,7 @@ class RFC1459Support(BasicClient):
 
         for channel, target in itertools.product(channels, targets):
             target, targetmeta = self._parse_user(target)
-            self._sync_user(target, targetmeta)
+            await self._sync_user(target, targetmeta)
 
             if self.is_same_nick(target, self.nickname):
                 self._destroy_channel(channel)
@@ -613,9 +613,9 @@ class RFC1459Support(BasicClient):
         target, targetmeta = self._parse_user(message.params[0])
         reason = message.params[1]
 
-        self._sync_user(target, targetmeta)
+        await self._sync_user(target, targetmeta)
         if by in self.users:
-            self._sync_user(by, bymeta)
+            await self._sync_user(by, bymeta)
 
         await self.on_kill(target, by, reason)
         if self.is_same_nick(self.nickname, target):
@@ -738,7 +738,7 @@ class RFC1459Support(BasicClient):
         setter, settermeta = self._parse_user(message.source)
         target, topic = message.params
 
-        self._sync_user(setter, settermeta)
+        await self._sync_user(setter, settermeta)
 
         # Update topic in our own channel list.
         if self.in_channel(target):
@@ -785,7 +785,7 @@ class RFC1459Support(BasicClient):
         }
 
         if nickname in self.users:
-            self._sync_user(nickname, info)
+            await self._sync_user(nickname, info)
         if nickname in self._pending['whois']:
             self._whois_info[nickname].update(info)
 


### PR DESCRIPTION
Found in #169 update, including in own PR per request. 

A number of _sync_user() calls should be awaited, and are not in the current code ( Caused by #164 )

This fixes that situation and ensures these calls are all awaited. 