### PR TITLE
Update supported versions as of v0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pydle
 Python IRC library.
 -------------------
 
-pydle is a compact, flexible and standards-abiding IRC library for Python 3.5+.
+pydle is a compact, flexible and standards-abiding IRC library for Python 3.5 through 3.9.
 
 Features
 --------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -4,7 +4,7 @@ Introduction to pydle
 
 What is pydle?
 --------------
-pydle is an IRC library for Python 3.5 through Python 3.9.
+pydle is an IRC library for Python 3.5 through 3.9.
 
 Although old and dated on some fronts, IRC is still used by a variety of communities as the real-time communication method of choice,
 and the most popular IRC networks can still count on tens of thousands of users at any point during the day.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -4,7 +4,7 @@ Introduction to pydle
 
 What is pydle?
 --------------
-pydle is an IRC library for Python 3.5 and up.
+pydle is an IRC library for Python 3.5 through Python 3.9.
 
 Although old and dated on some fronts, IRC is still used by a variety of communities as the real-time communication method of choice,
 and the most popular IRC networks can still count on tens of thousands of users at any point during the day.
@@ -35,7 +35,7 @@ All dependencies can be installed using the standard package manager for Python,
 
 Compatibility
 -------------
-pydle works in any interpreter that implements Python 3.5 or higher. Although mainly tested in CPython_, the standard Python implementation,
+pydle works in any interpreter that implements Python 3.5-3.9. Although mainly tested in CPython_, the standard Python implementation,
 there is no reason why pydle itself should not work in alternative implementations like PyPy_, as long as they support the Python 3.5 language requirements.
 
 .. _CPython: https://python.org


### PR DESCRIPTION
Pydle does not, as of v0.9.4, support Python 3.10 (Ref #162). This change makes this clear in the documentation and could be reverted once proper support for 3.10 has been implemented.