### PR TITLE
[#166] Add LIST Support

### DIFF
--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -914,10 +914,10 @@ class RFC1459Support(BasicClient):
             self.all_channels.append(channel_dict)
 
         # Clear the supporting lists
-        self._list_client = []
-        self._list_channel = []
-        self._list_count = []
-        self._list_topic = []
+        self._list_client.clear()
+        self._list_channel.clear()
+        self._list_count.clear()
+        self._list_topic.clear()
         if not self._list_query.empty():
             future = await self._list_query.get()
             future.set_result(self.all_channels)

--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -889,7 +889,7 @@ class RFC1459Support(BasicClient):
 
     async def on_raw_321(self, message):
         """RPL_LISTSTART, an OPTIONAL indication a LIST is starting."""
-        pass
+        ...
 
     async def on_raw_322(self, message):
         """RPL_LIST, the list of channels from the server"""
@@ -918,8 +918,9 @@ class RFC1459Support(BasicClient):
         self._list_channel = []
         self._list_count = []
         self._list_topic = []
-        future = await self._list_query.get()
-        future.set_result(self.all_channels)
+        if not self._list_query.empty():
+            future = await self._list_query.get()
+            future.set_result(self.all_channels)
 
     async def on_raw_324(self, message):
         """ Channel mode. """


### PR DESCRIPTION
Adds support for the LIST command (defined by RFC1459 Section 4.2.6) and adds a new function (BasicClient.channel_list). The channel_list function returns an updated channel listing of all channels and details of channels generated by the LIST command. 

This differs from the existing BasicClient.channels, which only return channels that Pylde is currently in, or considers itself to already be in.

Resolves #166