### PR TITLE
Add support for Python 3.10 by dropping event loop handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pydle
 Python IRC library.
 -------------------
 
-pydle is a compact, flexible and standards-abiding IRC library for Python 3.6 through 3.9.
+pydle is a compact, flexible and standards-abiding IRC library for Python 3.7 through 3.10.
 
 Features
 --------
@@ -65,9 +65,7 @@ Furthermore, since pydle is simply `asyncio`-based, you can run the client in yo
 import asyncio
 
 client = MyOwnBot('MyBot')
-loop = asyncio.get_event_loop()
-asyncio.ensure_future(client.connect('irc.rizon.net', tls=True, tls_verify=False), loop=loop)
-loop.run_forever()
+asyncio.run(client.connect('irc.rizon.net', tls=True, tls_verify=False))
 ```
 
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -4,7 +4,7 @@ Introduction to pydle
 
 What is pydle?
 --------------
-pydle is an IRC library for Python 3.6 through 3.9.
+pydle is an IRC library for Python 3.7 through 3.10.
 
 Although old and dated on some fronts, IRC is still used by a variety of communities as the real-time communication method of choice,
 and the most popular IRC networks can still count on tens of thousands of users at any point during the day.
@@ -35,8 +35,8 @@ All dependencies can be installed using the standard package manager for Python,
 
 Compatibility
 -------------
-pydle works in any interpreter that implements Python 3.6-3.9. Although mainly tested in CPython_, the standard Python implementation,
-there is no reason why pydle itself should not work in alternative implementations like PyPy_, as long as they support the Python 3.6 language requirements.
+pydle works in any interpreter that implements Python 3.7-3.10. Although mainly tested in CPython_, the standard Python implementation,
+there is no reason why pydle itself should not work in alternative implementations like PyPy_, as long as they support the Python 3.7 language requirements.
 
 .. _CPython: https://python.org
 .. _PyPy: http://pypy.org

--- a/pydle/connection.py
+++ b/pydle/connection.py
@@ -102,7 +102,7 @@ class Connection:
 
     def stop(self):
         """ Stop connection. """
-        asyncio.run(self.disconnect())
+        asyncio.create_task(self.disconnect())
 
     async def send(self, data):
         """ Add data to send queue. """

--- a/pydle/connection.py
+++ b/pydle/connection.py
@@ -21,7 +21,7 @@ class Connection:
 
     def __init__(self, hostname, port, tls=False, tls_verify=True, tls_certificate_file=None,
                  tls_certificate_keyfile=None, tls_certificate_password=None, ping_timeout=240,
-                 source_address=None, eventloop=None):
+                 source_address=None):
         self.hostname = hostname
         self.port = port
         self.source_address = source_address
@@ -36,7 +36,6 @@ class Connection:
 
         self.reader = None
         self.writer = None
-        self.eventloop = eventloop or asyncio.new_event_loop()
 
     async def connect(self):
         """ Connect to target. """
@@ -49,8 +48,7 @@ class Connection:
             host=self.hostname,
             port=self.port,
             local_addr=self.source_address,
-            ssl=self.tls_context,
-            loop=self.eventloop
+            ssl=self.tls_context
         )
 
     def create_tls_context(self):
@@ -103,8 +101,8 @@ class Connection:
         return self.reader is not None and self.writer is not None
 
     def stop(self):
-        """ Stop event loop. """
-        self.eventloop.call_soon(self.eventloop.stop)
+        """ Stop connection. """
+        asyncio.run(self.disconnect())
 
     async def send(self, data):
         """ Add data to send queue. """

--- a/pydle/features/ircv3/metadata.py
+++ b/pydle/features/ircv3/metadata.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from . import cap
 
 VISIBLITY_ALL = '*'
@@ -28,7 +30,7 @@ class MetadataSupport(cap.CapabilityNegotiationSupport):
 
             self._metadata_queue.append(target)
             self._metadata_info[target] = {}
-            self._pending['metadata'][target] = self.eventloop.create_future()
+            self._pending['metadata'][target] = asyncio.get_event_loop().create_future()
 
         return self._pending['metadata'][target]
 

--- a/pydle/features/ircv3/sasl.py
+++ b/pydle/features/ircv3/sasl.py
@@ -1,5 +1,6 @@
 ## sasl.py
 # SASL authentication support. Currently we only support PLAIN authentication.
+import asyncio
 import base64
 from functools import partial
 
@@ -47,7 +48,7 @@ class SASLSupport(cap.CapabilityNegotiationSupport):
         await self.rawmsg('AUTHENTICATE', mechanism)
         # create a partial, required for our callback to get the kwarg
         _sasl_partial = partial(self._sasl_abort, timeout=True)
-        self._sasl_timer = self.eventloop.call_later(self.SASL_TIMEOUT, _sasl_partial)
+        self._sasl_timer = asyncio.get_event_loop().call_later(self.SASL_TIMEOUT, _sasl_partial)
 
     async def _sasl_abort(self, timeout=False):
         """ Abort SASL authentication. """
@@ -166,7 +167,7 @@ class SASLSupport(cap.CapabilityNegotiationSupport):
             await self._sasl_respond()
         else:
             # Response not done yet. Restart timer.
-            self._sasl_timer = self.eventloop.call_later(self.SASL_TIMEOUT, self._sasl_abort(timeout=True))
+            self._sasl_timer = asyncio.get_event_loop().call_later(self.SASL_TIMEOUT, self._sasl_abort(timeout=True))
 
     on_raw_900 = cap.CapabilityNegotiationSupport._ignored  # You are now logged in as...
 

--- a/pydle/features/rfc1459/client.py
+++ b/pydle/features/rfc1459/client.py
@@ -1,5 +1,6 @@
 ## rfc1459.py
 # Basic RFC1459 stuff.
+import asyncio
 import copy
 import datetime
 import ipaddress
@@ -398,7 +399,7 @@ class RFC1459Support(BasicClient):
         # We just check if there's a space in the nickname -- if there is,
         # then we immediately set the future's result to None and don't bother checking.
         if protocol.ARGUMENT_SEPARATOR.search(nickname) is not None:
-            result = self.eventloop.create_future()
+            result = asyncio.get_event_loop().create_future()
             result.set_result(None)
             return result
 
@@ -412,7 +413,7 @@ class RFC1459Support(BasicClient):
             }
 
             # Create a future for when the WHOIS requests succeeds.
-            self._pending['whois'][nickname] = self.eventloop.create_future()
+            self._pending['whois'][nickname] = asyncio.get_event_loop().create_future()
 
         return await self._pending['whois'][nickname]
 
@@ -425,7 +426,7 @@ class RFC1459Support(BasicClient):
         """
         # Same treatment as nicknames in whois.
         if protocol.ARGUMENT_SEPARATOR.search(nickname) is not None:
-            result = self.eventloop.create_future()
+            result = asyncio.get_event_loop().create_future()
             result.set_result(None)
             return result
 
@@ -434,7 +435,7 @@ class RFC1459Support(BasicClient):
             self._whowas_info[nickname] = {}
 
             # Create a future for when the WHOWAS requests succeeds.
-            self._pending['whowas'][nickname] = self.eventloop.create_future()
+            self._pending['whowas'][nickname] = asyncio.get_event_loop().create_future()
 
         return await self._pending['whowas'][nickname]
 

--- a/pydle/features/tls.py
+++ b/pydle/features/tls.py
@@ -46,8 +46,7 @@ class TLSSupport(rfc1459.RFC1459Support):
                 tls=tls, tls_verify=tls_verify,
                 tls_certificate_file=self.tls_client_cert,
                 tls_certificate_keyfile=self.tls_client_cert_key,
-                tls_certificate_password=self.tls_client_cert_password,
-                eventloop=self.eventloop)
+                tls_certificate_password=self.tls_client_cert_password)
             self.encoding = encoding
 
         # Connect.

--- a/pydle/utils/irccat.py
+++ b/pydle/utils/irccat.py
@@ -56,7 +56,7 @@ async def _main():
 def main():
     # Setup logging.
     logging.basicConfig(format='!! %(levelname)s: %(message)s')
-    asyncio.get_event_loop().run_until_complete(_main())
+    asyncio.run(_main())
 
 
 if __name__ == '__main__':

--- a/pydle/utils/run.py
+++ b/pydle/utils/run.py
@@ -6,9 +6,7 @@ from . import _args
 
 def main():
     client, connect = _args.client_from_args('pydle', description='pydle IRC library.')
-    loop = asyncio.get_event_loop()
-    asyncio.ensure_future(connect(), loop=loop)
-    loop.run_forever()
+    asyncio.run(connect())
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ keywords = ["irc", "library","python3","compact","flexible"]
 license = "BSD"
 
 [tool.poetry.dependencies]
-python = ">=3.6;<3.10"
+python = ">=3.7;<3.11"
 
 [tool.poetry.dependencies.pure-sasl]
 version = "^0.6.2"

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -66,7 +66,6 @@ class MockClient(pydle.client.BasicClient):
             port,
             mock_client=self,
             mock_server=self._mock_server,
-            eventloop=self.eventloop,
         )
         await self.connection.connect()
         await self.on_connect()


### PR DESCRIPTION
Implements suggestions in
https://github.com/Shizmob/pydle/issues/162#issuecomment-1079797049 to
remove Pydle's internal handling of the event loop object entirely.

All tests are passing (although they are passing without these changes, too). I have been running [my own project](https://github.com/felixonmars/telegramirc) with this change and so far so good.

I am not sure about the connection pool though (I have never used it). This change should have also stopped it from having multiple event loops at all. So I have updated the `stop()` method from stopping the whole event loop to just `asyncio.run` the `disconnect()` method.