### PR TITLE
Update PyProject, Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ class Client(MyBase):
 
 **Q: How do I...?**
 
-Stop! Read the [documentation](http://pydle.readthedocs.org) first. If you're still in need of support, join us on IRC! We hang at `#pydle` on `irc.libera.chat`. If someone is around, they'll most likely gladly help you.
+Stop! Read the [documentation](http://pydle.readthedocs.org) first. If you're still in need of support, please [raise a new issue](https://github.com/Shizmob/pydle/issues/new) in this repository!
 
 License
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,12 @@ name = "pydle"
 version = "1.0.1"
 description = "A compact, flexible, and standards-abiding IRC library for python3."
 authors = ["Shiz <hi@shiz.me>"]
+maintainers = ["Joshua Salzedo  <joshuasalzedo@gmail.com>",]
 repository = "https://github.com/Shizmob/pydle"
 keywords = ["irc", "library","python3","compact","flexible"]
-license = "BSD"
+license = "BSD-3-Clause"
+readme = "README.md"
+documentation = "https://pydle.readthedocs.io/"
 
 [tool.poetry.dependencies]
 python = ">=3.6,<3.10"


### PR DESCRIPTION
Adds a few new fields to the PyProject file indicating a more specific license version, readme location, documentation link, and maintainer information. Also removes IRC from the preferred communication method and redirects people seeking aid to the repository ticketing solution.