### PR TITLE
Remove not used coroutine import

### DIFF
--- a/pydle/__init__.py
+++ b/pydle/__init__.py
@@ -1,5 +1,5 @@
 # noinspection PyUnresolvedReferences
-from asyncio import coroutine, Future
+from asyncio import Future
 from functools import cmp_to_key
 from . import connection, protocol, client, features
 from .client import Error, NotInChannel, AlreadyInChannel, BasicClient, ClientPool


### PR DESCRIPTION
coroutine is removed from python since python 3.11, it's imported in the __init__.py file but not used anywhere so that can be removed safely.